### PR TITLE
[DEV-38209] Allow librabbitmq connection error to be deduped for Sentry

### DIFF
--- a/kombu/transport/base.py
+++ b/kombu/transport/base.py
@@ -222,6 +222,13 @@ class Transport(object):
                 if exc.errno in _unavail:
                     return
                 raise
+            except SystemError as sys_err:
+                # Dedupe this exception with a common error message for Sentry;
+                # the error from librabbitmq contains an object memory address
+                # and thus does not get correctly deduped by Sentry
+                if 'built-in method _basic_recv of Connection object' in str(sys_err):
+                    raise SystemError('Error draining from librabbitmq connection')
+                raise
             loop.call_soon(_read, loop)
 
         return _read


### PR DESCRIPTION
Hopefully this should group errors like this one together in Sentry: https://sentry.io/organizations/rovercom/issues/1218514541/?project=12858&referrer=slack

Unfortunately I don't have a reasonable way to test this...