### PR TITLE
[DEV-38209_b] Make error deduping a bit more generic

### DIFF
--- a/kombu/transport/base.py
+++ b/kombu/transport/base.py
@@ -226,7 +226,12 @@ class Transport(object):
                 # Dedupe this exception with a common error message for Sentry;
                 # the error from librabbitmq contains an object memory address
                 # and thus does not get correctly deduped by Sentry
-                if 'built-in method _basic_recv of Connection object' in str(sys_err):
+                error_message = str(sys_err)
+                should_reraise = (
+                    'built-in method' in error_message
+                    and 'of Connection object' in error_message
+                )
+                if should_reraise:
                     raise SystemError('Error draining from librabbitmq connection')
                 raise
             loop.call_soon(_read, loop)


### PR DESCRIPTION
This handling code was only catching errors from `_basic_recv` but apparently they happen on other built-in methods as well: https://sentry.io/organizations/rovercom/issues/1206635921/?project=12858&query=is%3Aunresolved+SystemError&statsPeriod=14d